### PR TITLE
Self-service atlas creation, S3 photo batch ingest, user guide updates

### DIFF
--- a/configuration/starter_assets.json
+++ b/configuration/starter_assets.json
@@ -1,0 +1,35 @@
+{
+    "public_roads": {
+        "type": "inlet",
+        "out_layer": "roads",
+        "config_def": "overture_roads"
+    },
+    "public_creeks": {
+        "type": "inlet",
+        "out_layer": "creeks",
+        "config_def": "nhd_creeks"
+    },
+    "public_landmarks": {
+        "type": "inlet",
+        "out_layer": "landmarks",
+        "config_def": "osm_poi"
+    },
+    "webmap": {
+        "type": "outlet",
+        "name": "webmap",
+        "in_layers": ["roads", "creeks", "landmarks"],
+        "config_def": "webmap",
+        "access": ["public", "internal", "admin"]
+    },
+    "webedit": {
+        "type": "outlet",
+        "name": "webedit",
+        "in_layers": ["roads", "creeks", "landmarks"],
+        "config_def": "webedit"
+    },
+    "html": {
+        "type": "outlet",
+        "name": "html",
+        "config_def": "static_html"
+    }
+}

--- a/configuration/starter_layers.json
+++ b/configuration/starter_layers.json
@@ -1,0 +1,26 @@
+[
+    {"name": "regions", "geometry_type": "polygon", "color": [50, 50, 50], "interaction": "interface", "access": ["admin"]},
+    {"name": "roads", "geometry_type": "linestring",
+        "color": [20, 20, 20], "add_labels": true, "label_color": [220, 0, 0],
+        "label_expression": "if(\"name\" IS NOT NULL AND length(trim(\"name\")) > 3, \"name\", NULL)",
+        "interaction": "interface", "vector_width": true,
+        "editable_columns": [
+            {"name": "name", "type": "string", "default": "Road"},
+            {
+                "name": "STREETTYPE",
+                "type": "radio",
+                "values": [
+                    {"STREETTYPE": "RD", "vector_width": 15},
+                    {"STREETTYPE": "ST", "vector_width": 10},
+                    {"STREETTYPE": "Other", "vector_width": 8}
+                ],
+                "default": {"STREETTYPE": "RD", "vector_width": 15}
+            }
+        ]
+    },
+    {"name": "creeks", "geometry_type": "linestring", "add_labels": true, "color": [50, 50, 200],
+     "interaction": "interface", "vector_width": true},
+    {"name": "landmarks", "geometry_type": "point", "color": [20, 155, 200], "add_labels": true,
+     "interaction": "interface",
+     "editable_columns": [{"name": "name", "type": "string", "default": ""}]}
+]

--- a/documents/user_guide.md
+++ b/documents/user_guide.md
@@ -1,5 +1,40 @@
 # Stewardship Atlas User Guide
 
+## Contents
+
+- [Overview](#overview)
+- [Examples and Use Cases](#examples-and-use-cases)
+- [Access and Data Control](#access-and-data-control)
+- [Viewing Data](#viewing-data)
+  - [Interactive Web Map](#interactive-web-map)
+  - [Printable Maps and Documents](#printable-maps-and-documents)
+  - [Jupyter Notebooks](#jupyter-notebooks)
+  - [Files and Exports to Other Platforms](#files-and-exports-to-other-platforms)
+- [Curating and Editing Data](#curating-and-editing-data)
+  - [Web-Based Editing](#web-based-editing)
+  - [Submitting Photos by Email](#submitting-photos-by-email)
+  - [Uploading Data](#uploading-data)
+  - [Direct Python Access](#direct-python-access-advanced)
+  - [Data Versioning](#data-versioning)
+- [Sharing Data](#sharing-data)
+- [Advanced Topics](#advanced-topics)
+  - [Creating a New Atlas](#creating-a-new-atlas)
+  - [Batch-Ingesting Photos from S3](#batch-ingesting-photos-from-s3)
+- [Technical Details](#technical-details)
+  - [System Requirements](#system-requirements)
+  - [Data Formats](#data-formats)
+  - [Getting Help](#getting-help)
+  - [Performance Tips](#performance-tips)
+  - [Privacy and Data Handling](#privacy-and-data-handling)
+  - [Diagnosing Email Photo Submissions](#diagnosing-email-photo-submissions)
+  - [Live Email Log in the Technical Console](#live-email-log-in-the-technical-console)
+  - [Adding a New Authorised Sender](#adding-a-new-authorised-sender)
+  - [Inspecting and Reprocessing Stuck Emails](#inspecting-and-reprocessing-stuck-emails)
+  - [Testing the Platform](#testing-the-platform)
+  - [Updates and Maintenance](#updates-and-maintenance)
+
+---
+
 ## Overview
 
 A Stewardship Atlas is a data set; a configuration for storing, processing, and sharing that data set; and a set of implementions for doing so.
@@ -297,6 +332,59 @@ For websites or presentations, you can embed atlas maps:
 - Use the web map URL in an iframe
 - Link to specific Gazetteer pages
 - Embed exported images from print outputs
+
+## Advanced Topics
+
+### Creating a New Atlas
+
+A new atlas can be created entirely through the web interface — no server access or configuration files required.
+
+1. Go to [fireatlas.org/create](https://fireatlas.org/create)
+2. **Draw the atlas area**: use the draw tool to sketch a polygon covering the geographic region of interest. The bounding box of your drawing becomes the atlas extent.
+3. **Name it**: enter a display name (e.g. *Salmon Creek VFD*). An atlas ID is generated automatically from the name (e.g. `scvfd`) — you can edit it before submitting.
+4. Click **Create Atlas**. A progress log shows what's happening. Creation typically takes under a minute.
+5. When complete you are redirected to the new atlas's public console.
+
+**What you get out of the box:**
+- Interactive web map with OpenMapTiles Terrain basemap
+- Web editing interface for roads, creeks, and landmarks layers
+- Admin and public consoles
+
+**First steps after creation:**
+
+The atlas starts with empty layers. To populate it with publicly available data, open the Admin Console and trigger the data inlets:
+
+- **Roads** — fetches road network from Overture Maps for your area
+- **Creeks** — fetches waterways from the USGS National Hydrography Dataset
+- **Landmarks** — fetches points of interest from OpenStreetMap
+
+Each fetch runs as a background job; refresh the console to see progress. Data quality varies by region — Overture and NHD have excellent coverage across the United States; OSM coverage is strong in populated areas.
+
+**Default credentials:**
+
+New atlases use shared default credentials: `admin` / `admin` and `internal` / `internal`. These are intentionally simple placeholders. Contact your platform administrator to set up credentials specific to your atlas before sharing access with your community.
+
+---
+
+### Batch-Ingesting Photos from S3
+
+If you have a collection of geotagged photos already stored in S3 that need to be added to an atlas layer, use `scripts/ingest_s3_photos.py`. It applies the same GPS extraction and delta-writing pipeline as the email inlet.
+
+```bash
+# Preview — no writes
+SWALES_ROOT=/root/swales_dev \
+python3 scripts/ingest_s3_photos.py scvfd s3://my-bucket/field-photos/2026-04/ --dry-run
+
+# Ingest into a specific layer
+SWALES_ROOT=/root/swales_dev \
+python3 scripts/ingest_s3_photos.py scvfd s3://my-bucket/field-photos/2026-04/ --layer poi
+```
+
+Photos without GPS EXIF data are skipped and reported on stdout. All valid photos from the run are written as a single delta batch. The `--layer` flag defaults to the atlas's configured `email_photo_default_layer`.
+
+Photos must be publicly readable at their S3 URL for the atlas web map to display them inline.
+
+---
 
 ## Technical Details
 

--- a/infrastructure/nginx/fireatlas.org
+++ b/infrastructure/nginx/fireatlas.org
@@ -86,6 +86,32 @@ location ~ ^/samuelsloop/staging/outlets/html/internal/ {
     }
     # Add additional atlas auth blocks here as new atlases are provisioned.
 
+    # Generic fallback auth blocks — cover any atlas not listed above.
+    # New atlases created via /create are protected automatically by these.
+    # To give an atlas its own credentials, add a specific block above these.
+    # shared.htpasswd contains default admin:admin and internal:internal credentials.
+    # Create it on the server: htpasswd -bc /root/swales_dev/roles/shared.htpasswd admin admin
+    #                          htpasswd -b  /root/swales_dev/roles/shared.htpasswd internal internal
+    location ~ /outlets/html/admin/ {
+        auth_basic "Atlas Admin";
+        auth_basic_user_file /root/swales_dev/roles/shared.htpasswd;
+    }
+    location ~ /outlets/html/internal/ {
+        auth_basic "Atlas Internal";
+        auth_basic_user_file /root/swales_dev/roles/shared.htpasswd;
+    }
+
+    # Atlas creation UI — proxy to webapp port 9000.
+    # Covers GET /create (page), POST /create_atlas (API), GET /create-status (poll),
+    # and GET /templates/* (static assets for the create page).
+    location ~ ^/(create|create_atlas|create-status|templates/) {
+        proxy_pass https://127.0.0.1:9000;
+        proxy_ssl_verify off;
+        proxy_ssl_session_reuse on;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
     listen 443 ssl;
     ssl_certificate /etc/letsencrypt/live/fireatlas.org-0001/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/fireatlas.org-0001/privkey.pem;

--- a/python/outlets.py
+++ b/python/outlets.py
@@ -1881,8 +1881,9 @@ def make_root_html(root_path_str):
 
     atlas_html += "<HR width='40%'><UL>"
     atlas_html += "\n".join( [f"<LI><A HREF='{a}/index.html'>{b}</A></LI>" for a,b in zip(atlas_path_list, atlas_name_list) ] )
-    
-    atlas_html += "</UL></CENTER></BODY></HTML>"
+    atlas_html += "</UL>"
+    atlas_html += "<HR width='40%'><p><A HREF='/create' style='font-size:1.1em;'>+ Create New Atlas</A></p>"
+    atlas_html += "</CENTER></BODY></HTML>"
     outpath = f"{root_path}/index.html"
     logger.info(atlas_html)
     with open(outpath, "w") as f:

--- a/python/webapp.py
+++ b/python/webapp.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI, HTTPException, BackgroundTasks, logger
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 import json
 from datetime import datetime
@@ -19,6 +21,7 @@ import sys
 #webapp_conf = json.load(open("webapp_conf.json"))
 
 SWALES_ROOT = os.environ['SWALES_ROOT']
+ATLAS_SHARED_DIR = os.environ.get('ATLAS_SHARED_DIR', '/root/data')
 print(f"Serving all atlases from {SWALES_ROOT}")
 
 # Boring Imports
@@ -50,6 +53,11 @@ app.add_middleware(
 STORAGE_DIR = "/root/data/uploads/"
 # os.makedirs(f"{STORAGE_DIR}/roads_deltas", exist_ok=True)
 
+# Serve templates directory for the create-atlas UI
+_templates_dir = versioning.atlas_path(local_path='templates', version='app')
+app.mount("/templates", StaticFiles(directory=str(_templates_dir)), name="templates")
+
+
 class JSONPayload(BaseModel):
     data: Dict[str, Any]
 
@@ -61,6 +69,17 @@ class PinToPOIPayload(BaseModel):
 class SQLQueryPayload(BaseModel):
     query: str
     return_format: str = 'csv'  # Default to CSV format
+
+class BBox(BaseModel):
+    west: float
+    east: float
+    north: float
+    south: float
+
+class CreateAtlasRequest(BaseModel):
+    name: str   # display name (e.g. "Salmon Creek VFD")
+    slug: str   # atlas ID / directory name (e.g. "scvfd")
+    bbox: BBox
 
 def extract_coordinates_from_url(url: str) -> tuple[float, float]:
     """Extract latitude and longitude from a Google Maps URL."""
@@ -380,6 +399,9 @@ async def refresh(swale: str, asset: str):
         print(traceback_str)
         raise HTTPException(status_code=500, detail=str(e))
 
+# Global dict to track atlas creation status, keyed by slug
+create_statuses: Dict[str, Any] = {}
+
 # Global variable to track publish status
 publish_status = {
     "publishing": False,
@@ -480,6 +502,98 @@ async def publish_status_check(swale: str):
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/create")
+async def create_page():
+    create_html = versioning.atlas_path(local_path='templates/create_atlas.html', version='app')
+    return FileResponse(str(create_html))
+
+
+@app.post("/create_atlas")
+async def create_atlas_endpoint(payload: CreateAtlasRequest, background_tasks: BackgroundTasks):
+    slug = payload.slug.strip()
+    if not re.match(r'^[a-zA-Z][a-zA-Z0-9_]*$', slug):
+        raise HTTPException(status_code=400, detail="slug must start with a letter and contain only letters, numbers, and underscores")
+    if (Path(SWALES_ROOT) / slug).exists():
+        raise HTTPException(status_code=409, detail=f"Atlas '{slug}' already exists")
+
+    create_statuses[slug] = {
+        "creating": True,
+        "started_at": datetime.now().isoformat(),
+        "finished_at": None,
+        "log": [["Starting atlas creation", datetime.now().isoformat()]]
+    }
+
+    bbox = {"west": payload.bbox.west, "east": payload.bbox.east,
+            "north": payload.bbox.north, "south": payload.bbox.south}
+
+    feature_collection = {
+        "type": "FeatureCollection",
+        "features": [{
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [bbox["west"], bbox["south"]],
+                    [bbox["east"], bbox["south"]],
+                    [bbox["east"], bbox["north"]],
+                    [bbox["west"], bbox["north"]],
+                    [bbox["west"], bbox["south"]]
+                ]]
+            },
+            "properties": {
+                "name": slug,
+                "description": payload.name,
+                "app_url": "https://fireatlas.org:9000",
+                "versioned_outlets": ["html", "webmap"]
+            }
+        }]
+    }
+
+    layers_path = str(versioning.atlas_path(local_path='configuration/starter_layers.json', version='app'))
+    assets_path = str(versioning.atlas_path(local_path='configuration/starter_assets.json', version='app'))
+
+    async def finish_creating():
+        try:
+            create_statuses[slug]["log"].append(["Creating atlas structure", datetime.now().isoformat()])
+            atlas.create(
+                layers_path=layers_path,
+                assets_path=assets_path,
+                data_root=SWALES_ROOT,
+                shared_dir=Path(ATLAS_SHARED_DIR),
+                feature_collection=feature_collection
+            )
+            create_statuses[slug]["log"].append(["Atlas structure created", datetime.now().isoformat()])
+
+            ac = json.load(open(Path(SWALES_ROOT) / slug / "staging" / "atlas_config.json"))
+            for outlet_name in ["html", "webmap", "webedit"]:
+                create_statuses[slug]["log"].append([f"Materializing {outlet_name}", datetime.now().isoformat()])
+                atlas.materialize(ac, outlet_name)
+                create_statuses[slug]["log"].append([f"Finished {outlet_name}", datetime.now().isoformat()])
+
+            create_statuses[slug]["log"].append(["Done", datetime.now().isoformat()])
+            create_statuses[slug]["creating"] = False
+            create_statuses[slug]["finished_at"] = datetime.now().isoformat()
+        except Exception as e:
+            logging.error(f"Error creating atlas {slug}: {e}")
+            logging.error(traceback.format_exc())
+            create_statuses[slug]["log"].append([f"ERROR: {e}", datetime.now().isoformat()])
+            create_statuses[slug]["creating"] = False
+            create_statuses[slug]["finished_at"] = datetime.now().isoformat()
+
+    background_tasks.add_task(finish_creating)
+    return {"status": "success", "creating": True, "atlas_slug": slug,
+            "started_at": create_statuses[slug]["started_at"]}
+
+
+@app.get("/create-status")
+async def create_status_check(atlas_slug: str):
+    if atlas_slug not in create_statuses:
+        raise HTTPException(status_code=404, detail=f"No creation in progress for '{atlas_slug}'")
+    s = create_statuses[atlas_slug]
+    return {"status": "success", "creating": s["creating"],
+            "started_at": s["started_at"], "finished_at": s["finished_at"], "log": s["log"]}
+
 
 @app.post("/sql_query/{swalename}")
 async def execute_sql_query(swalename: str, payload: SQLQueryPayload):

--- a/scripts/ingest_s3_photos.py
+++ b/scripts/ingest_s3_photos.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Batch-ingest geotagged photos from an S3 directory into an atlas layer.
+
+Photos must have GPS EXIF data. Each valid photo becomes a point feature
+in the target layer, identical to what the email photo inlet produces.
+Photos without GPS are skipped and reported on stdout.
+
+Usage:
+    python3 scripts/ingest_s3_photos.py <atlas_name> s3://<bucket>/<prefix> [options]
+
+    SWALES_ROOT env var must be set (same as running the webapp).
+
+Options:
+    --layer LAYER       target layer name (default: config's email_photo_default_layer, then "poi")
+    --sender TEXT       provenance string in feature properties (default: "s3_import")
+    --dry-run           print what would be ingested without writing anything
+    --profile PROFILE   AWS profile name (default: atlas)
+
+Example:
+    SWALES_ROOT=/root/swales_dev \\
+    python3 scripts/ingest_s3_photos.py scvfd s3://my-bucket/field-photos/2026-04/ --dry-run
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import boto3
+
+# Allow importing from python/
+sys.path.insert(0, str(Path(__file__).parent.parent / 'python'))
+
+import dataswale_geojson
+import deltas_geojson
+import email_inlet
+
+IMAGE_EXTENSIONS = {'.jpg', '.jpeg', '.png', '.tiff', '.tif'}
+
+
+def parse_s3_url(s3_url: str):
+    """Parse 's3://bucket/prefix' into (bucket, prefix)."""
+    if not s3_url.startswith('s3://'):
+        raise ValueError(f"S3 URL must start with s3://: {s3_url}")
+    parts = s3_url[5:].split('/', 1)
+    bucket = parts[0]
+    prefix = parts[1] if len(parts) > 1 else ''
+    return bucket, prefix
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('atlas_name', help='Atlas slug (e.g. scvfd)')
+    parser.add_argument('s3_url', help='S3 location to scan, e.g. s3://bucket/prefix/')
+    parser.add_argument('--layer', help='Target layer name (default: from atlas config)')
+    parser.add_argument('--sender', default='s3_import', help='Provenance string (default: s3_import)')
+    parser.add_argument('--dry-run', action='store_true', help='Preview only, no writes')
+    parser.add_argument('--profile', default='atlas', help='AWS profile name (default: atlas)')
+    args = parser.parse_args()
+
+    # Load atlas config
+    swales_root = os.environ.get('SWALES_ROOT')
+    if not swales_root:
+        print('ERROR: SWALES_ROOT environment variable is not set', file=sys.stderr)
+        sys.exit(1)
+
+    config_path = Path(swales_root) / args.atlas_name / 'staging' / 'atlas_config.json'
+    if not config_path.exists():
+        print(f'ERROR: Atlas config not found at {config_path}', file=sys.stderr)
+        sys.exit(1)
+
+    config = json.load(open(config_path))
+
+    # Resolve layer name
+    layer_name = args.layer or config.get('email_photo_default_layer', 'poi')
+    layer_names = {l['name'] for l in config['dataswale'].get('layers', [])}
+    if layer_name not in layer_names:
+        print(f"ERROR: Layer '{layer_name}' not found in atlas. Available: {sorted(layer_names)}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse S3 URL
+    try:
+        bucket, prefix = parse_s3_url(args.s3_url)
+    except ValueError as e:
+        print(f'ERROR: {e}', file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Atlas:   {args.atlas_name}")
+    print(f"Layer:   {layer_name}")
+    print(f"Source:  s3://{bucket}/{prefix}")
+    print(f"Sender:  {args.sender}")
+    if args.dry_run:
+        print("Mode:    dry-run (no writes)")
+    print()
+
+    # List objects
+    session = boto3.Session(profile_name=args.profile)
+    s3 = session.client('s3')
+    paginator = s3.get_paginator('list_objects_v2')
+
+    features = []
+    n_skip = 0
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get('Contents', []):
+            key = obj['Key']
+            ext = Path(key).suffix.lower()
+            if ext not in IMAGE_EXTENSIONS:
+                continue
+
+            # Download
+            try:
+                resp = s3.get_object(Bucket=bucket, Key=key)
+                image_bytes = resp['Body'].read()
+            except Exception as e:
+                print(f"SKIP {key}: download error — {e}")
+                n_skip += 1
+                continue
+
+            # Extract GPS
+            gps = email_inlet.extract_gps(image_bytes)
+            if not gps:
+                print(f"SKIP {key}: no GPS data")
+                n_skip += 1
+                continue
+            if 'lat' not in gps or 'lon' not in gps:
+                print(f"SKIP {key}: incomplete GPS ({gps})")
+                n_skip += 1
+                continue
+
+            title = Path(key).stem
+            timestamp = obj['LastModified'].isoformat()
+            image_url = f"https://{bucket}.s3.amazonaws.com/{key}"
+            extra_props = {k: v for k, v in gps.items() if k not in ('lat', 'lon')}
+
+            feature = email_inlet.build_feature(
+                lat=gps['lat'],
+                lon=gps['lon'],
+                title=title,
+                sender=args.sender,
+                timestamp=timestamp,
+                image_url=image_url,
+                extra_props=extra_props,
+            )
+            features.append(feature)
+            print(f"OK   {key}  lat={gps['lat']:.5f} lon={gps['lon']:.5f}")
+
+    print()
+    print(f"Result: {len(features)} OK, {n_skip} skipped")
+
+    if not features:
+        print("Nothing to ingest.")
+        return
+
+    if args.dry_run:
+        print("Dry-run: no delta written.")
+        return
+
+    # Write single delta for the whole batch
+    fc = {"type": "FeatureCollection", "features": features}
+    deltas_geojson.add_deltas_from_features(config, "s3_import", fc, "create", layer_name=layer_name)
+
+    # Refresh layer
+    dataswale_geojson.refresh_vector_layer(config, layer_name)
+
+    print(f"Wrote {len(features)} features to layer '{layer_name}'.")
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/create_atlas.html
+++ b/templates/create_atlas.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Create New Atlas</title>
+    <script src='https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.js'></script>
+    <script src="https://unpkg.com/terra-draw@1.0.0-beta.0/dist/terra-draw.umd.js"></script>
+    <link href='https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.css' rel='stylesheet' />
+    <link href='/templates/css/map.css' rel='stylesheet' />
+    <link href='/templates/css/shared_controls.css' rel='stylesheet' />
+</head>
+<body>
+    <div id="controls">
+        <div class="control-panel title-panel">
+            <h4>Create New Atlas</h4>
+            <a href="/" class="button link-button">Home</a>
+        </div>
+
+        <div class="control-panel">
+            <label>Atlas Name:</label>
+            <input type="text" id="atlas-name" class="input-field" placeholder="e.g. Salmon Creek VFD">
+            <label style="margin-top:8px;">Atlas ID:</label>
+            <input type="text" id="atlas-slug" class="input-field" placeholder="e.g. scvfd">
+            <div id="slug-error" style="color:#c00; font-size:12px; margin-top:4px; display:none;"></div>
+        </div>
+
+        <div class="control-panel view-panel">
+            <label>Basemap:</label>
+            <select id="basemap-select" class="input-field">
+                <option value="terrain" selected>OpenMapTiles Terrain</option>
+                <option value="satellite">Satellite (ESRI)</option>
+                <option value="usgs">USGS Topo</option>
+                <option value="shaded-relief">USGS Shaded Relief</option>
+            </select>
+        </div>
+
+        <div class="control-panel">
+            <p style="margin:0 0 6px 0; font-size:13px;">Draw a rectangle to define the atlas area, then submit.</p>
+            <button id="draw-btn" class="button" style="width:100%; margin-bottom:6px;">Draw Area</button>
+            <button id="clear-btn" class="button" style="width:100%; margin-bottom:6px;" disabled>Clear</button>
+            <button id="submit-btn" class="button" style="width:100%; background:#2a6;" disabled>Create Atlas</button>
+        </div>
+
+        <div id="progress-panel" class="control-panel" style="display:none;">
+            <label>Progress:</label>
+            <div id="progress-log" style="font-size:12px; max-height:200px; overflow-y:auto; background:#111; color:#9f9; padding:6px; border-radius:4px; font-family:monospace;"></div>
+        </div>
+
+        <div id="loading-progress" class="progress-bar" style="display:none;">
+            <div class="progress-fill"></div>
+            <div class="progress-text">Creating atlas...</div>
+        </div>
+    </div>
+
+    <div id="map"></div>
+
+    <script>
+    const TERRAIN_SOURCE = {
+        type: 'raster',
+        tiles: ['https://tile.opentopomap.org/{z}/{x}/{y}.png'],
+        tileSize: 256,
+        attribution: 'Map data: &copy; OpenStreetMap contributors, SRTM | Map style: &copy; OpenTopoMap (CC-BY-SA)'
+    };
+    const SATELLITE_SOURCE = {
+        type: 'raster',
+        tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles &copy; Esri'
+    };
+    const USGS_SOURCE = {
+        type: 'raster',
+        tiles: ['https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}'],
+        tileSize: 256,
+        attribution: 'Tiles courtesy of the U.S. Geological Survey'
+    };
+    const SHADED_RELIEF_SOURCE = {
+        type: 'raster',
+        tiles: ['https://basemap.nationalmap.gov/arcgis/services/USGSShadedReliefOnly/MapServer/WMSServer?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&LAYERS=0&STYLES=&FORMAT=image/png&TRANSPARENT=true&CRS=EPSG:3857&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}'],
+        tileSize: 256,
+        attribution: 'USGS Shaded Relief'
+    };
+
+    const BASEMAP_SOURCES = { terrain: TERRAIN_SOURCE, satellite: SATELLITE_SOURCE, usgs: USGS_SOURCE, 'shaded-relief': SHADED_RELIEF_SOURCE };
+
+    const map = new maplibregl.Map({
+        container: 'map',
+        style: {
+            version: 8,
+            sources: { basemap: TERRAIN_SOURCE },
+            layers: [{ id: 'basemap-layer', type: 'raster', source: 'basemap' }]
+        },
+        center: [-120, 38],
+        zoom: 5
+    });
+
+    map.addControl(new maplibregl.NavigationControl(), 'top-left');
+
+    document.getElementById('basemap-select').addEventListener('change', function() {
+        map.getSource('basemap').setTiles(BASEMAP_SOURCES[this.value].tiles);
+    });
+
+    // TerraDraw polygon mode — user draws any shape, we extract the bbox
+    let td = null;
+    let drawnBbox = null;
+
+    function nameToSlug(name) {
+        return name.toLowerCase()
+            .replace(/[^a-z0-9\s_]/g, '')
+            .trim()
+            .replace(/\s+/g, '_')
+            .replace(/^[0-9_]+/, '');
+    }
+
+    document.getElementById('atlas-name').addEventListener('input', function() {
+        const slugField = document.getElementById('atlas-slug');
+        slugField.value = nameToSlug(this.value);
+        validateSlug();
+    });
+
+    document.getElementById('atlas-slug').addEventListener('input', validateSlug);
+
+    function validateSlug() {
+        const slug = document.getElementById('atlas-slug').value;
+        const err = document.getElementById('slug-error');
+        if (!slug) { err.style.display = 'none'; return false; }
+        if (!/^[a-zA-Z][a-zA-Z0-9_]*$/.test(slug)) {
+            err.textContent = 'Must start with a letter; only letters, numbers, underscore allowed.';
+            err.style.display = 'block';
+            return false;
+        }
+        err.style.display = 'none';
+        return true;
+    }
+
+    function updateSubmitBtn() {
+        const slug = document.getElementById('atlas-slug').value;
+        const valid = drawnBbox && slug && /^[a-zA-Z][a-zA-Z0-9_]*$/.test(slug);
+        document.getElementById('submit-btn').disabled = !valid;
+    }
+
+    map.on('load', function() {
+        td = new TerraDraw.TerraDraw({
+            adapter: new TerraDraw.TerraDrawMapLibreGLAdapter({ map }),
+            modes: [
+                new TerraDraw.TerraDrawPolygonMode(),
+                new TerraDraw.TerraDrawSelectMode({ flags: { polygon: { feature: { draggable: true } } } })
+            ]
+        });
+        td.start();
+
+        td.on('finish', function() {
+            const features = td.getSnapshot();
+            if (!features.length) return;
+            const coords = features[0].geometry.coordinates[0];
+            const lons = coords.map(c => c[0]);
+            const lats = coords.map(c => c[1]);
+            drawnBbox = {
+                west: Math.min(...lons),
+                east: Math.max(...lons),
+                south: Math.min(...lats),
+                north: Math.max(...lats)
+            };
+            document.getElementById('clear-btn').disabled = false;
+            document.getElementById('draw-btn').disabled = true;
+            updateSubmitBtn();
+        });
+    });
+
+    document.getElementById('draw-btn').addEventListener('click', function() {
+        td.setMode('polygon');
+    });
+
+    document.getElementById('clear-btn').addEventListener('click', function() {
+        td.clear();
+        drawnBbox = null;
+        this.disabled = true;
+        document.getElementById('draw-btn').disabled = false;
+        document.getElementById('submit-btn').disabled = true;
+    });
+
+    document.getElementById('submit-btn').addEventListener('click', async function() {
+        if (!validateSlug() || !drawnBbox) return;
+        const name = document.getElementById('atlas-name').value.trim() || document.getElementById('atlas-slug').value;
+        const slug = document.getElementById('atlas-slug').value.trim();
+
+        this.disabled = true;
+        document.getElementById('draw-btn').disabled = true;
+        document.getElementById('clear-btn').disabled = true;
+        document.getElementById('progress-panel').style.display = 'block';
+        document.getElementById('loading-progress').style.display = 'block';
+
+        let resp;
+        try {
+            resp = await fetch('/create_atlas', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name, slug, bbox: drawnBbox })
+            });
+        } catch(e) {
+            appendLog('ERROR: ' + e.message);
+            return;
+        }
+
+        if (!resp.ok) {
+            const detail = (await resp.json()).detail || resp.statusText;
+            appendLog('ERROR: ' + detail);
+            document.getElementById('loading-progress').style.display = 'none';
+            return;
+        }
+
+        pollStatus(slug);
+    });
+
+    function appendLog(msg) {
+        const log = document.getElementById('progress-log');
+        log.textContent += msg + '\n';
+        log.scrollTop = log.scrollHeight;
+    }
+
+    async function pollStatus(slug) {
+        while (true) {
+            await new Promise(r => setTimeout(r, 1500));
+            let data;
+            try {
+                const r = await fetch('/create-status?atlas_slug=' + encodeURIComponent(slug));
+                data = await r.json();
+            } catch(e) {
+                appendLog('Poll error: ' + e.message);
+                continue;
+            }
+            const log = document.getElementById('progress-log');
+            log.textContent = data.log.map(e => e[0]).join('\n');
+            log.scrollTop = log.scrollHeight;
+
+            if (!data.creating) {
+                document.getElementById('loading-progress').style.display = 'none';
+                if (data.log.some(e => e[0].startsWith('ERROR'))) {
+                    appendLog('\nCreation failed. Check server logs.');
+                } else {
+                    appendLog('\nRedirecting to your new atlas...');
+                    setTimeout(() => { window.location.href = '/' + slug + '/staging/outlets/html/public'; }, 1500);
+                }
+                break;
+            }
+        }
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `GET /create` page — draw a bbox, enter a name, spin up a new atlas with starter layers (roads, creeks, landmarks) in ~30s
- `POST /create_atlas` + `GET /create-status` — background creation with progress polling
- Nginx: generic fallback auth blocks using `shared.htpasswd` so new atlases need no per-atlas nginx config changes; proxy locations for `/create*` and `/templates/`
- `configuration/starter_layers.json` + `starter_assets.json` — minimal layer/asset set for new atlases
- `scripts/ingest_s3_photos.py` — batch-ingest geotagged photos from any S3 prefix using the same pipeline as the email inlet
- User guide: table of contents + "Creating a New Atlas" section under Advanced Topics

## Deploy checklist

Before reloading nginx, create `shared.htpasswd` on the server:
```bash
htpasswd -bc /root/swales_dev/roles/shared.htpasswd admin admin
htpasswd -b  /root/swales_dev/roles/shared.htpasswd internal internal
```
Then copy nginx config and reload:
```bash
nginx -t && nginx -s reload
```

## Related

Closes #44 is out of scope for this PR — tracked separately.