### PR TITLE
Add move-features-between-layers to webedit (issue #72)

### DIFF
--- a/python/deltas_geojson.py
+++ b/python/deltas_geojson.py
@@ -144,6 +144,37 @@ def add_deltas_from_features(
     return [ str(outpath) ]
 
 
+def extract_intersecting_features(layer_path: Path, polygon_fc: dict) -> List[Feature]:
+    """Return features from layer_path whose geometry intersects any polygon in polygon_fc.
+
+    polygon_fc must be a GeoJSON FeatureCollection dict (not a path).
+    """
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.geojson', delete=False) as f:
+        json.dump(polygon_fc, f)
+        sel_path = f.name
+    try:
+        duckdb.sql("INSTALL spatial; LOAD spatial;")
+        duckdb.sql(f"DROP TABLE IF EXISTS _sel_poly; CREATE TABLE _sel_poly AS SELECT * FROM ST_Read('{sel_path}');")
+        duckdb.sql(f"DROP TABLE IF EXISTS _src_feats; CREATE TABLE _src_feats AS SELECT COLUMNS('.*') AS \"feat_\\0\" FROM ST_Read('{layer_path}');")
+        res = duckdb.sql("""
+            SELECT ST_AsGeoJSON(feat_geom) AS geometry, * EXCLUDE (feat_geom)
+            FROM _src_feats
+            WHERE EXISTS (
+                SELECT 1 FROM _sel_poly WHERE ST_Intersects(_sel_poly.geom, feat_geom)
+            )
+        """)
+        return [
+            Feature(
+                geometry=geojson.loads(row[0]),
+                properties={col[len("feat_"):]: val for col, val in zip(res.columns[1:], row[1:])}
+            )
+            for row in res.fetchall()
+        ]
+    finally:
+        os.unlink(sel_path)
+
+
 def _apply_delete_delta(layer_filepath: Path, delta_filepath: Path) -> None:
     """Remove layer features that intersect the drawn polygon in the delete delta.
 

--- a/python/outlets.py
+++ b/python/outlets.py
@@ -606,6 +606,23 @@ def outlet_webmap(config, name):
   
     return output_path
 
+def candidate_move_targets(config: dict, source_layer_name: str) -> list:
+    """Return layer names that can receive features moved from source_layer_name.
+
+    Currently filters by matching geometry_type and excludes the source layer.
+    Isolated as a function so richer logic can be added without touching call sites.
+    """
+    source_def = next((l for l in config['dataswale']['layers'] if l['name'] == source_layer_name), None)
+    if not source_def:
+        return []
+    source_geom = source_def.get('geometry_type', '')
+    return [
+        l['name']
+        for l in config['dataswale']['layers']
+        if l['name'] != source_layer_name and l.get('geometry_type') == source_geom
+    ]
+
+
 def generate_edit_controls_html(editable_attributes, geometry_type='point'):
     """Generate HTML for edit controls based on attribute configuration"""
     select_html = ""
@@ -653,6 +670,15 @@ def generate_edit_controls_html(editable_attributes, geometry_type='point'):
             <button id="delete-cancel-button" class="button">Cancel</button>
             <button id="delete-confirm-button" class="warning-button">Delete</button>
         </div>
+        <div class="button-group" id="move-button-group">
+            <button id="move-button" class="button">Move to Layer</button>
+        </div>
+        <div id="move-confirm" style="display:none; margin-top: 8px;">
+            <p style="margin: 0 0 8px 0; font-size: 0.9em;">Move features in selected area to:</p>
+            <select id="move-target-select" class="input-field" style="margin-bottom: 8px;"></select>
+            <button id="move-cancel-button" class="button">Cancel</button>
+            <button id="move-confirm-button" class="button">Move Features</button>
+        </div>
     """
 
     return select_html + string_html + buttons_html
@@ -690,6 +716,8 @@ def generate_edit_page( config: dict, ea: dict, name: str, map_config: dict, act
     basemap_is_raster_edit = bool(webedit_in_layers) and layers_dict_edit.get(webedit_in_layers[0], {}).get('geometry_type') == 'raster'
     lidar_basemap_option = '<option value="hillshade">Hillshade</option>\n                ' if basemap_is_raster_edit else ''
 
+    move_targets = candidate_move_targets(config, ea['name'])
+
     # Format template
     return template.format(
         swale_name=config['name'],
@@ -702,7 +730,8 @@ def generate_edit_page( config: dict, ea: dict, name: str, map_config: dict, act
         mode_string=mode_string,
         controls_config=json.dumps(controls_config),
         legend_targets=json.dumps(map_config.get('legend_targets', {}), indent=2),
-        lidar_basemap_option=lidar_basemap_option)
+        lidar_basemap_option=lidar_basemap_option,
+        move_targets=json.dumps(move_targets))
 
 def outlet_webmap_edit(config: dict, name: str):
     """Generate an interactive web map edit using MapLibre GL JS - one for each editable asset"""

--- a/python/webapp.py
+++ b/python/webapp.py
@@ -85,6 +85,11 @@ class CreateAtlasRequest(BaseModel):
     slug: str   # atlas ID / directory name (e.g. "scvfd")
     bbox: BBox
 
+class MovePayload(BaseModel):
+    source_layer: str
+    target_layer: str
+    selection: Dict[str, Any]  # GeoJSON Feature or FeatureCollection of selection polygon(s)
+
 def extract_coordinates_from_url(url: str) -> tuple[float, float]:
     """Extract latitude and longitude from a Google Maps URL."""
     import re
@@ -315,6 +320,68 @@ async def json_upload(payload: JSONPayload, swalename: str):
         print(f"ERROR in json_upload. {e}")
         traceback_str = ''.join(traceback.format_tb(e.__traceback__))
         print(traceback_str)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/move_features/{swalename}")
+async def move_features(payload: MovePayload, swalename: str):
+    try:
+        config_path = Path(SWALES_ROOT) / swalename / "staging" / "atlas_config.json"
+        ac = json.load(open(config_path))
+
+        source_path = versioning.atlas_path(ac, "layers") / payload.source_layer / f"{payload.source_layer}.geojson"
+        target_path = versioning.atlas_path(ac, "layers") / payload.target_layer / f"{payload.target_layer}.geojson"
+
+        source_snapshot = source_path.read_text()
+        target_snapshot = target_path.read_text() if target_path.exists() else None
+
+        sel = payload.selection
+        if sel.get("type") == "Feature":
+            sel_fc = {"type": "FeatureCollection", "features": [sel]}
+        elif sel.get("type") == "FeatureCollection":
+            sel_fc = sel
+        else:
+            raise HTTPException(status_code=400, detail="selection must be a GeoJSON Feature or FeatureCollection")
+
+        moved = deltas_geojson.extract_intersecting_features(source_path, sel_fc)
+        if not moved:
+            return {"moved": 0, "source_remaining": len(json.loads(source_snapshot)["features"])}
+
+        delta_files_written = []
+        try:
+            create_fc = {"type": "FeatureCollection", "layer": payload.target_layer, "action": "create", "features": [dict(f) for f in moved]}
+            target_delta = deltas_geojson.delta_path_from_layer(ac, payload.target_layer, "create")
+            with open(target_delta, "w") as f:
+                json.dump(create_fc, f)
+            delta_files_written.append(Path(target_delta))
+            dataswale_geojson.refresh_vector_layer(ac, payload.target_layer)
+
+            delete_fc = dict(sel_fc)
+            delete_fc["layer"] = payload.source_layer
+            delete_fc["action"] = "delete"
+            source_delta = deltas_geojson.delta_path_from_layer(ac, payload.source_layer, "delete")
+            with open(source_delta, "w") as f:
+                json.dump(delete_fc, f)
+            delta_files_written.append(Path(source_delta))
+            dataswale_geojson.refresh_vector_layer(ac, payload.source_layer)
+
+            source_remaining = len(json.loads(source_path.read_text())["features"])
+            return {"moved": len(moved), "source_remaining": source_remaining}
+
+        except Exception as e:
+            for p in delta_files_written:
+                if p.exists():
+                    p.unlink()
+            source_path.write_text(source_snapshot)
+            if target_snapshot is not None:
+                target_path.write_text(target_snapshot)
+            raise HTTPException(status_code=500, detail=str(e))
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        traceback_str = ''.join(traceback.format_tb(e.__traceback__))
+        print(f"ERROR in move_features: {e}\n{traceback_str}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/templates/edit_map.html
+++ b/templates/edit_map.html
@@ -64,6 +64,7 @@
             controls: {controls_config}
         }};
         const LEGEND_TARGETS = {legend_targets};
+        const MOVE_TARGETS = {move_targets};
         const SATELLITE_SOURCE = {{
             'type': 'raster',
             'tiles': [

--- a/templates/js/edit_map.js
+++ b/templates/js/edit_map.js
@@ -11,6 +11,22 @@ const modeMap = {
     'polygon': 'TerraDrawPolygonMode'
 };
 
+// Populate the move target dropdown and hide the move section if no targets exist
+(function initMoveTargets() {
+    const select = document.getElementById('move-target-select');
+    const group = document.getElementById('move-button-group');
+    if (!MOVE_TARGETS || MOVE_TARGETS.length === 0) {
+        if (group) group.style.display = 'none';
+        return;
+    }
+    MOVE_TARGETS.forEach(function(name) {
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.text = name;
+        select.appendChild(opt);
+    });
+})();
+
 // Initialize Terra Draw with all possible modes
 const td = new terraDraw.TerraDraw({
     adapter: new terraDraw.TerraDrawMapLibreGLAdapter({
@@ -389,6 +405,61 @@ if (uploadPhotoBtn) {
         fileInput.click();
     });
 }
+
+// Move to Layer — show confirm panel
+document.getElementById('move-button').addEventListener('click', function() {
+    const features = td.getSnapshot();
+    if (features.length === 0) {
+        showErrorPopup('No area drawn. Please draw a polygon to select features to move.');
+        return;
+    }
+    document.getElementById('move-confirm').style.display = 'block';
+});
+
+document.getElementById('move-cancel-button').addEventListener('click', function() {
+    document.getElementById('move-confirm').style.display = 'none';
+});
+
+document.getElementById('move-confirm-button').addEventListener('click', function() {
+    const features = td.getSnapshot();
+    if (features.length === 0) {
+        showErrorPopup('No area drawn.');
+        return;
+    }
+    const targetLayer = document.getElementById('move-target-select').value;
+    if (!targetLayer) {
+        showErrorPopup('Please select a target layer.');
+        return;
+    }
+
+    const selection = features.length === 1
+        ? features[0]
+        : {"type": "FeatureCollection", "features": features};
+
+    const payload = {
+        source_layer: EDIT_CONFIG.layerName,
+        target_layer: targetLayer,
+        selection: selection
+    };
+
+    fetch(EDIT_CONFIG.appUrl + '/move_features/' + EDIT_CONFIG.swalename, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    }).then(function(r) {
+        return r.json().then(function(data) { return {ok: r.ok, data: data}; });
+    }).then(function(result) {
+        if (result.ok) {
+            document.getElementById('move-confirm').style.display = 'none';
+            td.clear();
+            showSuccessNotification('Moved ' + result.data.moved + ' feature(s) to ' + targetLayer);
+        } else {
+            showErrorPopup('Move failed: ' + (result.data.detail || 'unknown error'));
+        }
+    }).catch(function(err) {
+        showErrorPopup('Move error: ' + err.message);
+    });
+});
 
 // Add upload button functionality
 document.getElementById('upload-button').addEventListener('click', function() {


### PR DESCRIPTION
Three-part implementation: backend endpoint, Python template injection, and frontend UI.

- deltas_geojson.py: extract_intersecting_features() helper uses DuckDB spatial join to find source features inside a drawn polygon
- webapp.py: POST /move_features/{swalename} — snapshots both layers, writes create delta to target and delete delta to source, refreshes both, restores on failure
- outlets.py: candidate_move_targets() filters layers by geometry type; generate_edit_page() injects MOVE_TARGETS; generate_edit_controls_html() adds Move to Layer button + confirm panel
- edit_map.html: adds MOVE_TARGETS JS constant placeholder
- edit_map.js: populates dropdown from MOVE_TARGETS, handles move button/cancel/confirm flow with fetch to new endpoint