### PR TITLE
Add email body field ingestion for editable columns

### DIFF
--- a/infrastructure/lambda/email_photo_handler.py
+++ b/infrastructure/lambda/email_photo_handler.py
@@ -24,6 +24,21 @@ s3 = boto3.client("s3")
 WEBAPP_URL = os.environ["WEBAPP_URL"]
 
 
+def extract_body_text(msg) -> str:
+    """Extract plain text body from a parsed email message.
+
+    Prefers text/plain; falls back to text/html. Returns empty string if none found.
+    """
+    for content_type in ("text/plain", "text/html"):
+        for part in msg.walk():
+            if part.get_content_type() == content_type:
+                try:
+                    return part.get_payload(decode=True).decode("utf-8", errors="replace").strip()
+                except Exception:
+                    pass
+    return ""
+
+
 def extract_atlas_name(msg) -> str | None:
     """Derive atlas name from the To: header.
 
@@ -76,6 +91,8 @@ def handler(event, context):
     logger.info(f"Subject: {subject}")
     logger.info(f"From: {sender}")
 
+    body_text = extract_body_text(msg)
+
     payload = {
         "subject": subject,
         "sender": sender,
@@ -83,6 +100,7 @@ def handler(event, context):
         "image_data": image_data,
         "filename": filename,
         "received_at": datetime.now(timezone.utc).isoformat(),
+        "body_text": body_text,
     }
 
     resp = requests.post(f"{WEBAPP_URL}/ingest/email_photo", json=payload, timeout=30)

--- a/python/email_inlet.py
+++ b/python/email_inlet.py
@@ -14,21 +14,69 @@ from utils import safe_float
 logger = logging.getLogger(__name__)
 
 
-def parse_subject(subject: str, default_layer: str = "poi") -> tuple[str, str]:
-    """Parse email subject into (layer_name, title).
+def parse_subject(subject: str) -> str:
+    """Return email subject as the feature title.
 
-    Format: "<layer_name>: <title>"
-    If no colon is present, the entire subject is used as the title
-    and the layer defaults to default_layer.
+    Layer is no longer extracted from the subject — use the email body instead.
     """
-    if ":" in subject:
-        layer_name, _, title = subject.partition(":")
-        layer_name = layer_name.strip().lower()
-        title = title.strip() or "Photo submission"
-    else:
-        layer_name = default_layer
-        title = subject.strip() or "Photo submission"
-    return layer_name, title
+    return subject.strip() or "Photo submission"
+
+
+def parse_body(body_text: str, layer_names: list, editable_columns: list) -> dict:
+    """Parse email body for layer selection and editable field values.
+
+    Returns {"layer": str|None, "props": dict, "raw": str}.
+
+    Layer detection (first match wins):
+    - Any line with "layer: <value>" or "layer=<value>" (case-insensitive key)
+    - First non-empty line with no separator that matches a known layer name
+
+    All other lines are scanned for "key: value" or "key=value" pairs whose
+    keys match editable column names (case-insensitive). Unknown keys ignored.
+
+    Never raises — returns {"layer": None, "props": {}, "raw": body_text or ""}
+    on any error.
+    """
+    raw = body_text or ""
+    try:
+        col_names = {c["name"].lower(): c["name"] for c in (editable_columns or [])}
+        layer_set = {n.lower() for n in (layer_names or [])}
+
+        layer = None
+        props = {}
+        first_line_checked = False
+
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            sep_pos = -1
+            for sep in (":", "="):
+                pos = line.find(sep)
+                if pos != -1 and (sep_pos == -1 or pos < sep_pos):
+                    sep_pos = pos
+
+            if sep_pos == -1:
+                # No separator — check if first non-empty line matches a layer name
+                if not first_line_checked and line.lower() in layer_set:
+                    layer = line.lower()
+                first_line_checked = True
+                continue
+
+            first_line_checked = True
+            key = line[:sep_pos].strip().lower()
+            value = line[sep_pos + 1:].strip()
+
+            if key == "layer":
+                if value.lower() in layer_set:
+                    layer = value.lower()
+            elif key in col_names:
+                props[col_names[key]] = value
+
+        return {"layer": layer, "props": props, "raw": raw}
+    except Exception:
+        return {"layer": None, "props": {}, "raw": raw}
 
 
 def _exif_to_json(value):
@@ -93,21 +141,28 @@ def extract_gps(image_bytes: bytes) -> dict | None:
 
 def build_feature(lat: float, lon: float, title: str, sender: str,
                   timestamp: str, image_url: str,
+                  body_props: dict = None,
                   extra_props: dict = None) -> geojson.Feature:
     """Build a GeoJSON Point feature from extracted data.
 
     GeoJSON coordinate order is [lon, lat].
+    body_props (parsed from email body) are applied first; extra_props (EXIF/GPS)
+    follow so GPS metadata wins over body values. Hardcoded fields always take
+    precedence over both.
     """
-    properties = {
+    properties = {}
+    if body_props:
+        properties.update(body_props)
+    if extra_props:
+        properties.update(extra_props)
+    properties.update({
         "name": title,
         "timestamp": timestamp,
         "source": "email",
         "sender": sender,
         "image_url": image_url,
         "URL": image_url,
-    }
-    if extra_props:
-        properties.update(extra_props)
+    })
 
     return geojson.Feature(
         geometry=geojson.Point((lon, lat)),

--- a/python/webapp.py
+++ b/python/webapp.py
@@ -948,6 +948,7 @@ class EmailPhotoPayload(BaseModel):
     image_data: str       # base64-encoded image bytes
     filename: str
     received_at: str
+    body_text: str | None = None
 
 
 class WebPhotoPayload(BaseModel):
@@ -1006,12 +1007,21 @@ async def ingest_email_photo(payload: EmailPhotoPayload):
         # See issue #61 for splitting photo-submission auth from admin_emails.
         admin_emails = ac.get("admin_emails", [])
 
-        # Parse subject
+        # Parse subject — now just the title; layer comes from body or config default
         default_layer = ac.get("email_photo_default_layer", "processing_sites")
-        layer_name, title = email_inlet.parse_subject(payload.subject, default_layer)
+        title = email_inlet.parse_subject(payload.subject)
 
-        # Validate layer exists; fall back to atlas default if subject named an unknown layer
         layer_names = [l["name"] for l in ac["dataswale"]["layers"]]
+
+        # Parse body for layer override and editable field values
+        default_layer_cfg = next(
+            (l for l in ac["dataswale"]["layers"] if l["name"] == default_layer), {}
+        )
+        editable_columns = default_layer_cfg.get("editable_columns", [])
+        body = email_inlet.parse_body(payload.body_text, layer_names, editable_columns)
+
+        # Layer resolution: body > config default
+        layer_name = body["layer"] or default_layer
         if layer_name not in layer_names:
             logging.warning(
                 f"Unknown layer '{layer_name}' for atlas '{payload.atlas_name}'; "
@@ -1060,6 +1070,10 @@ async def ingest_email_photo(payload: EmailPhotoPayload):
 
         extra_props = {k: v for k, v in gps.items() if k not in ("lat", "lon")}
 
+        body_props = dict(body["props"])
+        if body["raw"]:
+            body_props["email_body"] = body["raw"]
+
         # Build feature and write delta
         feature = email_inlet.build_feature(
             lat=gps["lat"],
@@ -1068,6 +1082,7 @@ async def ingest_email_photo(payload: EmailPhotoPayload):
             sender=payload.sender,
             timestamp=payload.received_at,
             image_url=image_url,
+            body_props=body_props,
             extra_props=extra_props,
         )
         fc = {"type": "FeatureCollection", "features": [feature]}


### PR DESCRIPTION
Email body is now parsed for layer selection and layer-specific field values (editable_columns). Layer can be specified as the first plain line matching a known layer name, or anywhere as "layer: <name>". Editable field values (e.g. "capacity: 5000") are stored in the delta feature. Raw body is always stored as email_body. Never fails on bad body — malformed or absent body falls through cleanly.

Layer is no longer extracted from the subject line (colon parsing was unreliable with forwarded mail and natural punctuation). Subject is now used as the feature title only. Lambda updated to extract and pass body_text; Lambda redeploy required.