### PR TITLE
Switch 3D terrain to AWS Open Data global tiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,9 @@ Even with correct min_zoom, partial tiles at DEM edges still have zero-fill. `te
 
 ### 3D Geometry Source
 
-For 3D terrain geometry (not hillshade), a global tile service beats local PMTiles — our atlas PMTiles sit in correct terrain but the surrounding world has a sharp edge. AWS Open Data terrain (Terrarium encoding, free, global) is seamless. Our own PMTiles are valuable for the 2D hillshade basemap only.
+The 3D view uses the AWS Open Data global terrain tile service (Terrarium encoding, `https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png`, max z15). This gives seamless terrain at atlas boundaries and ~10m resolution for US atlases. No local terrain-RGB tiles are generated or stored.
+
+Hillshade PMTiles (for the 2D basemap visual texture) remain local and are unaffected — they are a separate pipeline from terrain geometry.
 
 ### PMTiles Technical Notes
 
@@ -372,7 +374,7 @@ htpasswd -b  /root/swales_dev/roles/shared.htpasswd internal internal
 
 ### pmtiles-terrain branch
 
-Not yet merged. SCVFD wired but not tested.
+Superseded by `feature/aws-terrain` — switched directly to AWS Open Data terrain instead of local PMTiles. Merged to main via that branch.
 
 ### Pending Issues
 

--- a/configuration/biochar_assets.json
+++ b/configuration/biochar_assets.json
@@ -71,12 +71,6 @@
         "out_layer": "basemap",
         "config_def": "derived_hillshade"
     },
-    "terrain_rgb_tiles": {
-        "type": "eddy",
-        "in_layer": "terrain_dem",
-        "out_layer": "terrain_rgb_tiles",
-        "config_def": "terrain_rgb_tiles"
-    },
     "hillshade_tiles": {
         "type": "eddy",
         "in_layer": "basemap",

--- a/configuration/fhe_assets.json
+++ b/configuration/fhe_assets.json
@@ -40,12 +40,6 @@
         "out_layer": "basemap",
         "config_def": "derived_hillshade"
     },
-    "terrain_rgb_tiles": {
-        "type": "eddy",
-        "in_layer": "terrain_dem",
-        "out_layer": "terrain_rgb_tiles",
-        "config_def": "terrain_rgb_tiles"
-    },
     "hillshade_tiles": {
         "type": "eddy",
         "in_layer": "basemap",

--- a/configuration/foresthealth_assets.json
+++ b/configuration/foresthealth_assets.json
@@ -40,12 +40,6 @@
         "out_layer": "basemap",
         "config_def": "derived_hillshade"
     },
-    "terrain_rgb_tiles": {
-        "type": "eddy",
-        "in_layer": "terrain_dem",
-        "out_layer": "terrain_rgb_tiles",
-        "config_def": "terrain_rgb_tiles"
-    },
     "hillshade_tiles": {
         "type": "eddy",
         "in_layer": "basemap",

--- a/configuration/kennedy_assets.json
+++ b/configuration/kennedy_assets.json
@@ -27,17 +27,6 @@
         "out_layer": "hillshade_tiles",
         "config_def": "hillshade_tiles"
     },
-    "terrain_dem": {
-        "type": "inlet",
-        "out_layer": "terrain_dem",
-        "config_def": "terrain_dem"
-    },
-    "terrain_rgb_tiles": {
-        "type": "eddy",
-        "in_layer": "terrain_dem",
-        "out_layer": "terrain_rgb_tiles",
-        "config_def": "terrain_rgb_tiles"
-    },
     "3dview": {
         "type": "outlet",
         "name": "3dview",

--- a/configuration/samuelsloop_assets.json
+++ b/configuration/samuelsloop_assets.json
@@ -27,17 +27,6 @@
         "out_layer": "hillshade_tiles",
         "config_def": "hillshade_tiles"
     },
-    "terrain_dem": {
-        "type": "inlet",
-        "out_layer": "terrain_dem",
-        "config_def": "terrain_dem"
-    },
-    "terrain_rgb_tiles": {
-        "type": "eddy",
-        "in_layer": "terrain_dem",
-        "out_layer": "terrain_rgb_tiles",
-        "config_def": "terrain_rgb_tiles"
-    },
     "3dview": {
         "type": "outlet",
         "name": "3dview",

--- a/configuration/scvfd_assets.json
+++ b/configuration/scvfd_assets.json
@@ -21,22 +21,11 @@
         "out_layer": "lidar_basemap",
         "config_def": "local_hillshade"
     },
-    "terrain_dem": {
-        "type": "inlet",
-        "out_layer": "terrain_dem",
-        "config_def": "terrain_dem"
-    },
     "hillshade_tiles": {
         "type": "eddy",
         "in_layer": "lidar_basemap",
         "out_layer": "hillshade_tiles",
         "config_def": "hillshade_tiles"
-    },
-    "terrain_rgb_tiles": {
-        "type": "eddy",
-        "in_layer": "terrain_dem",
-        "out_layer": "terrain_rgb_tiles",
-        "config_def": "terrain_rgb_tiles"
     },
     "3dview": {
         "type": "outlet",

--- a/configuration/starter_assets.json
+++ b/configuration/starter_assets.json
@@ -71,12 +71,6 @@
         "out_layer": "basemap",
         "config_def": "derived_hillshade"
     },
-    "terrain_rgb_tiles": {
-        "type": "eddy",
-        "in_layer": "terrain_dem",
-        "out_layer": "terrain_rgb_tiles",
-        "config_def": "terrain_rgb_tiles"
-    },
     "hillshade_tiles": {
         "type": "eddy",
         "in_layer": "basemap",

--- a/python/3dview.py
+++ b/python/3dview.py
@@ -13,8 +13,8 @@ import utils
 
 _VECTOR_INCLUDE_TYPES = {'linestring', 'point', 'polygon'}
 _INDEX_SUFFIXES = ('_index',)
-_TERRAIN_URL_PLACEHOLDER = '__TERRAIN_URL__'
 _GLYPHS_URL = 'https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf'
+_AWS_TERRAIN_TILES = 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png'
 
 # Layer names containing any of these substrings start visible; all others start hidden.
 _DEFAULT_VISIBLE_PATTERNS = ('road', 'creek', 'stream', 'photo')
@@ -154,35 +154,9 @@ def _build_toggle_panel_html(toggle_list: list) -> str:
 
 def generate_3d_terrain_html(config: Dict[str, Any]) -> str:
     """
-    Generate a 3D terrain HTML page using MapLibre GL JS + PMTiles.
-
-    Requires terrain_rgb_tiles eddy to have been run first to produce
-    layers/terrain_rgb_tiles/terrain_rgb_tiles.pmtiles.
+    Generate a 3D terrain HTML page using MapLibre GL JS with AWS Open Data terrain.
     """
     atlas_name = config['name']
-    atlas_path = versioning.atlas_path(config)
-
-    layers_dict = {l['name']: l for l in config['dataswale']['layers']}
-    terrain_layer_config = layers_dict.get('terrain_rgb_tiles', {})
-
-    if terrain_layer_config.get('cog'):
-        s3_bucket = terrain_layer_config.get('cog_s3_bucket', 'scs-atlas-data')
-        s3_region = terrain_layer_config.get('cog_s3_region', 'us-east-1')
-        terrain_cog_url = (f"https://{s3_bucket}.s3.{s3_region}.amazonaws.com"
-                           f"/{atlas_name}/rasters/terrain_rgb_tiles/terrain_rgb_tiles.cog.tif")
-        terrain_url_js_line = f"const terrainUrl = 'cog://{terrain_cog_url}';"
-    else:
-        terrain_rgb_file = atlas_path / "layers" / "terrain_rgb_tiles" / "terrain_rgb_tiles.pmtiles"
-        if not terrain_rgb_file.exists():
-            raise FileNotFoundError(
-                f"terrain_rgb_tiles.pmtiles not found at {terrain_rgb_file} — "
-                "run the terrain_rgb_tiles eddy first"
-            )
-        terrain_rgb_rel_path = "../../layers/terrain_rgb_tiles/terrain_rgb_tiles.pmtiles"
-        terrain_url_js_line = (
-            f"const terrainUrl = 'pmtiles://' + "
-            f"new URL('{terrain_rgb_rel_path}', window.location.href).href;"
-        )
 
     bbox = config['dataswale']['bbox']
     center_lng = (bbox['west'] + bbox['east']) / 2
@@ -204,9 +178,11 @@ def generate_3d_terrain_html(config: Dict[str, Any]) -> str:
             },
             "terrain": {
                 "type": "raster-dem",
-                "url": _TERRAIN_URL_PLACEHOLDER,
-                "encoding": "mapbox",
+                "tiles": [_AWS_TERRAIN_TILES],
+                "encoding": "terrarium",
                 "tileSize": 256,
+                "maxzoom": 15,
+                "attribution": "Terrain &copy; Mapzen/AWS Open Data",
             },
             **vector_sources,
         },
@@ -217,9 +193,7 @@ def generate_3d_terrain_html(config: Dict[str, Any]) -> str:
         ],
         "terrain": {"source": "terrain", "exaggeration": 1.5},
     }
-    style_json = json.dumps(style, indent=4).replace(
-        f'"{_TERRAIN_URL_PLACEHOLDER}"', 'terrainUrl'
-    )
+    style_json = json.dumps(style, indent=4)
 
     layer_toggle_js = ""
     if toggle_list:
@@ -387,8 +361,6 @@ def generate_3d_terrain_html(config: Dict[str, Any]) -> str:
         maplibregl.addProtocol('pmtiles', protocol.tile);
         maplibregl.addProtocol('cog', MaplibreCOGProtocol.cogProtocol);
 
-        {terrain_url_js_line}
-
         const map = new maplibregl.Map({{
             container: 'map',
             zoom: 14,
@@ -435,7 +407,6 @@ def generate_3d_terrain_html(config: Dict[str, Any]) -> str:
         {layer_toggle_js}
         map.on('load', () => {{
             console.log('3D Terrain map loaded — atlas: {atlas_name}');
-            console.log('Terrain PMTiles:', terrainUrl);
         }});
 
         map.on('error', (e) => {{


### PR DESCRIPTION
## Summary

- Replaces locally-generated terrain-RGB PMTiles (COP30, Mapbox encoding) with the AWS Open Data global terrain tile service (Terrarium encoding, `elevation-tiles-prod`, max z15)
- Gives seamless terrain at atlas boundaries — no more hard edge where the atlas ends
- ~10m resolution for US atlases vs 30m COP30
- Removes `terrain_rgb_tiles` eddy from all atlas asset configs; removes `terrain_dem` inlet where it only fed `terrain_rgb_tiles` (scvfd, kennedy, samuelsloop — kept where it also feeds `derived_hillshade`)
- `3dview.py` simplified by ~33 lines — static tile URL replaces PMTiles/COG conditional logic

## Test plan

- [ ] Pull branch on server, `build_atlas.py config_only` for each atlas
- [ ] `atlas.materialize(config, '3dview')` for SCVFD (or any atlas with 3dview)
- [ ] Open 3dview, tilt camera — terrain should render with no flat edge at atlas boundary
- [ ] Confirm surrounding world has correct elevation (not sea-level flat)
- [ ] Confirm no JS console errors related to terrain
- [ ] Confirm hillshade still appears correctly (separate pipeline, should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)