### PR TITLE
feat: collapsible NAV panel and loading overlay on webmap

### DIFF
--- a/templates/css/shared_controls.css
+++ b/templates/css/shared_controls.css
@@ -39,6 +39,67 @@
     font-weight: bold;
 }
 
+/* Collapse toggle button */
+.nav-collapse-btn {
+    position: relative;
+    z-index: 11;
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    padding: 0 2px;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #666;
+    line-height: 1;
+    font-family: inherit;
+}
+
+.nav-collapse-btn:hover {
+    color: #000;
+}
+
+/* Collapsed state */
+#controls.collapsed {
+    background: rgba(255, 255, 255, 0.15) !important;
+}
+
+#controls.collapsed .title-panel {
+    background: rgba(255, 255, 255, 0.4);
+    margin-bottom: 0;
+}
+
+#controls.collapsed #nav-body {
+    display: none;
+}
+
+/* Nav body wrapper — needed for overlay positioning */
+#nav-body {
+    position: relative;
+}
+
+/* Loading overlay — covers nav-body panels while tiles load */
+#nav-loading-overlay {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(160, 160, 160, 0.65);
+    border-radius: 6px;
+    z-index: 10;
+    justify-content: center;
+    align-items: center;
+    font-size: 0.85em;
+    color: #222;
+    font-weight: bold;
+    pointer-events: all;
+}
+
+#controls.loading #nav-loading-overlay {
+    display: flex;
+}
+
 .qr-toggle {
     flex-shrink: 0;
     background: none;

--- a/templates/js/webmap.js
+++ b/templates/js/webmap.js
@@ -155,8 +155,10 @@ map.on('load', async () => {
         }
     }
 
-    // Initialize enhanced progress tracking
-    const updateProgress = initializeProgressTracking(map, 5); // basemap + 4 basemaps
+    // Remove loading overlay once all tiles are rendered
+    map.once('idle', () => {
+        document.getElementById('controls').classList.remove('loading');
+    });
 
     map.addSource('satellite', SATELLITE_SOURCE);
     map.addSource('usgs', USGS_SOURCE);
@@ -625,4 +627,15 @@ map.on('load', async () => {
 
     // Initialize help popup
     initializeHelpPopup(document.getElementById('help-popup').querySelector('.help-body').innerHTML);
+
+    // Collapse toggle
+    const collapseBtn = document.getElementById('nav-collapse-btn');
+    if (collapseBtn) {
+        collapseBtn.addEventListener('click', () => {
+            const controls = document.getElementById('controls');
+            const collapsed = controls.classList.toggle('collapsed');
+            collapseBtn.textContent = collapsed ? '▸' : '▾';
+            collapseBtn.title = collapsed ? 'Expand panel' : 'Collapse panel';
+        });
+    }
 });

--- a/templates/map.html
+++ b/templates/map.html
@@ -14,48 +14,49 @@
 
 </head>
 <body>
-    <div id="controls">
+    <div id="controls" class="loading">
         <!-- Title Panel -->
         <div class="control-panel title-panel">
             <h4>{title}</h4>
             {qr_code}
+            <button id="nav-collapse-btn" class="nav-collapse-btn" title="Collapse panel">▾</button>
         </div>
-        
-        <!-- View Panel -->
-        <div class="control-panel view-panel">
-            <label>Basemap:</label>
-            <select id="basemap-select" class="input-field">
-                {lidar_basemap_option}<option value="usgs">USGS Topo</option>
-                <option value="satellite">Satellite (ESRI)</option>
-                <option value="terrain">OpenMapTiles Terrain</option>
-                <option value="shaded-relief">USGS Shaded Relief (WMS)</option>
-            </select>
-        </div>
-        
-        <!-- Sharing Panel -->
-        <div class="control-panel sharing-panel">
-            <button id="share-view-btn" class="button" style="width: 100%; padding: 5px; margin-bottom: 5px;">Share</button>
-            <label>Share format:</label>
-            <select id="coords-format-select" class="input-field">
-                <option value="json">JSON coordinates</option>
-                <option value="google">Google Maps link</option>
-                <option value="internal">Internal map link</option>
-            </select>
-            <input type="text" id="location-input" class="input-field" placeholder="paste location here" style="width: calc(100% - 50px); display: inline-block;">
-            <button id="go-location-btn" class="button" style="width: 40px; margin-left: 5px; padding: 5px;">Go</button>
-        </div>
-        
-        <!-- Navigation Panel -->
-        <div class="control-panel nav-panel">
-            <a href="../html/admin" class="button link-button">Home</a>
-            <a href="../3dview/" class="button link-button">3D</a>
-            <a href="#" class="button link-button" id="help-link">?</a>
-        </div>
-        
-        <!-- Progress Bar -->
-        <div id="loading-progress" class="progress-bar">
-            <div class="progress-fill"></div>
-            <div class="progress-text">Loading layers...</div>
+
+        <!-- Collapsible body -->
+        <div id="nav-body">
+            <!-- Loading overlay (covers nav-body while tiles load; position:absolute so doesn't affect flow) -->
+            <div id="nav-loading-overlay"><span>Loading layers...</span></div>
+
+            <!-- View Panel -->
+            <div class="control-panel view-panel">
+                <label>Basemap:</label>
+                <select id="basemap-select" class="input-field">
+                    {lidar_basemap_option}<option value="usgs">USGS Topo</option>
+                    <option value="satellite">Satellite (ESRI)</option>
+                    <option value="terrain">OpenMapTiles Terrain</option>
+                    <option value="shaded-relief">USGS Shaded Relief (WMS)</option>
+                </select>
+            </div>
+
+            <!-- Sharing Panel -->
+            <div class="control-panel sharing-panel">
+                <button id="share-view-btn" class="button" style="width: 100%; padding: 5px; margin-bottom: 5px;">Share</button>
+                <label>Share format:</label>
+                <select id="coords-format-select" class="input-field">
+                    <option value="json">JSON coordinates</option>
+                    <option value="google">Google Maps link</option>
+                    <option value="internal">Internal map link</option>
+                </select>
+                <input type="text" id="location-input" class="input-field" placeholder="paste location here" style="width: calc(100% - 50px); display: inline-block;">
+                <button id="go-location-btn" class="button" style="width: 40px; margin-left: 5px; padding: 5px;">Go</button>
+            </div>
+
+            <!-- Navigation Panel -->
+            <div class="control-panel nav-panel">
+                <a href="../html/admin" class="button link-button">Home</a>
+                <a href="../3dview/" class="button link-button">3D</a>
+                <a href="#" class="button link-button" id="help-link">?</a>
+            </div>
         </div>
     </div>
     <div id="map"></div>


### PR DESCRIPTION
- Adds ▾/▸ collapse button to title panel; toggling hides the body panels and makes the whole control box more transparent (outer rgba 0.3→0.15, title panel rgba 0.8→0.4)
- Replaces the broken bottom progress bar with a gray overlay that covers the view/sharing/nav panels while tiles load, with pointer-events blocking; cleared on map.once('idle')
- Collapse button stays interactive during loading (z-index above the overlay) so users can dismiss the panel while tiles are still fetching